### PR TITLE
Mempool dev

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -47,6 +47,9 @@ pub async fn connect(
             }
             NetworkMessage::Verack => {
                 println!("Received verack message: {:?}", msg);
+            },
+            NetworkMessage::Ping(u) => {
+                sender.send(NetworkMessage::Pong(u)).await.unwrap();
             }
             _ => (),
         };

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -131,7 +131,7 @@ fn build_version_message(
     let nonce: u64 = secp256k1::rand::thread_rng().gen();
 
     // Construct the message
-    NetworkMessage::Version(VersionMessage::new(
+    let mut msg = VersionMessage::new(
         services,
         timestamp as i64,
         addr_recv,
@@ -139,5 +139,7 @@ fn build_version_message(
         nonce,
         user_agent,
         start_height,
-    ))
+    );
+    msg.relay = true;
+    NetworkMessage::Version(msg)
 }

--- a/src/sync/utxo.rs
+++ b/src/sync/utxo.rs
@@ -165,14 +165,13 @@ where
                                     Ok::<(), UtxoSyncError>(())
                                 }
                             }).await?;
-                        let flush_h = start_h + flush_period;
                         finish_block(
                             db.clone(),
                             cache.clone(),
                             fork_height,
                             max_coins,
                             flush_period,
-                            flush_h,
+                            start_h,
                             end_h,
                             false,
                         )


### PR DESCRIPTION
Small changes related to mempool filters ticket in ergvein repo

* Pong back on ping messages
* Enable relay flag in Version message. Without it the node does not relay mempool invs or any invs to the listener
* Fix erroneous condition on flushing the cache to db. It failed in cases when flush period was higher than the concurrent block batch size, since in that case start_height + batch_size never surpassed the flush_period. Now it's ``start_h.div(flush_period) != end_h.div(flush_period)``
* Added two functions which retrieve UTXO from UTXO cache without asking for the block height and without modifying the cache. Used for mempool